### PR TITLE
Update OLED status with network and UDP details

### DIFF
--- a/src/devices/Oled.h
+++ b/src/devices/Oled.h
@@ -10,6 +10,8 @@
 #include <U8g2lib.h>
 
 class Logger;
+class ConfigStore;
+class UdpService;
 class Oled {
 public:
   explicit Oled(Logger *logger);
@@ -18,7 +20,7 @@ public:
   // session and prepares the display. Must be called after wire
   // initialization (implicitly done by U8g2).
   void begin();
-
+  
   // Update the status screen. Shows network SSID, PIN and a summary
   // of service states. Should be called periodically (e.g. once per
   // second).
@@ -29,6 +31,9 @@ public:
   // condition prevents the normal operation of the firmware.
   void showError(const String &msg);
 
+  void setConfigStore(ConfigStore *config);
+  void setUdpService(UdpService *udp);
+
 private:
   U8G2_SSD1306_128X64_NONAME_F_HW_I2C m_u8g2;
   Logger *m_logger;
@@ -38,6 +43,12 @@ private:
   int8_t m_sdaPin = -1;
   int8_t m_sclPin = -1;
   uint32_t m_i2cClockHz = 100000;
+  ConfigStore *m_config = nullptr;
+  UdpService *m_udpService = nullptr;
+
+  String resolveLoginPin();
+  void computeIoCounts(size_t &inputs, size_t &outputs);
+  String currentWifiMode() const;
 };
 
 #endif // MINILABOESP_OLED_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,6 +94,8 @@ void setup() {
   // started early so that error messages can be displayed, then the
   // DMM, function generator and web/UDP services. Each module will
   // reference the configuration and logger as required.
+  oled.setConfigStore(&configStore);
+  oled.setUdpService(&udpService);
   oled.begin();
   dmm.begin();
   funcGen.begin();

--- a/src/services/UdpService.h
+++ b/src/services/UdpService.h
@@ -19,6 +19,7 @@ public:
   UdpService(ConfigStore *config, IORegistry *ioReg, Logger *logger);
   void begin();
   void loop();
+  bool isRunning() const { return m_running; }
 
 private:
   WiFiUDP m_udp;
@@ -28,6 +29,8 @@ private:
   IORegistry *m_io;
   Logger *m_logger;
   unsigned long m_lastSend;
+  bool m_enabled;
+  bool m_running;
 };
 
 #endif // MINILABOESP_UDPSERVICE_H


### PR DESCRIPTION
## Summary
- Load the OLED login PIN from the stored network configuration and expand the status screen with Wi-Fi mode, UDP state, and IO counters.
- Allow the UDP service to be disabled through configuration, track its running state, and expose it for display.
- Provide the OLED with configuration and UDP service context during setup so the screen reflects current settings.

## Testing
- `pio run` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db01b6bae4832e83f2598515b2f2ae