### PR TITLE
Align serial monitor speed with firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# MiniLabo ESP8266 Firmware
+
+This repository contains the firmware for the MiniLabo ESP8266 board. The
+project is built with PlatformIO and targets the `nodemcuv2` board using the
+Arduino framework.
+
+## Serial console settings
+
+The ESP8266 boot ROM prints diagnostics at **74880 baud**. The firmware keeps the
+serial port at the same speed so that the boot loader messages and the
+application logs stay aligned.
+
+When using the PlatformIO device monitor (or any other serial terminal) make
+sure it is configured for 74880 baud; otherwise the console will show garbled
+characters during and after boot which can make debugging networking issues
+impossible.
+
+```
+pio device monitor -b 74880
+```
+
+With the correct baud rate you will see the normal boot output and messages such
+as the SoftAP SSID and IP address that confirm the web server and Wi-Fi
+services are running.

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,7 @@ framework = arduino
 
 ; Use LittleFS as the filesystem. This must match the FS used in code.
 board_build.filesystem = littlefs
-monitor_speed = 115200
+monitor_speed = 74880
 
 ; External dependencies. ArduinoJson handles configuration and API
 ; responses. U8g2 is included for OLED support. Adafruit


### PR DESCRIPTION
## Summary
- update PlatformIO monitor speed to match the firmware's 74880 baud configuration
- document the required serial console settings to avoid garbled boot output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db1f81a394832eb924afd21e7a17b2