### PR TITLE
Replace FileWriteService queue with fixed ring buffer

### DIFF
--- a/src/services/FileWriteService.h
+++ b/src/services/FileWriteService.h
@@ -12,8 +12,6 @@
 #pragma once
 
 #include <Arduino.h>
-#include <queue>
-
 class FileWriteService {
 public:
   // Initialize the service. Currently no state to initialize.
@@ -31,10 +29,14 @@ public:
   size_t pending() const;
 
 private:
+  static constexpr size_t kMaxQueueLength = 8;
   struct Task {
     String path;
     String contents;
   };
-  std::queue<Task> m_queue;
+  Task m_tasks[kMaxQueueLength];
+  size_t m_head{0};
+  size_t m_tail{0};
+  size_t m_count{0};
   bool m_busy{false};
 };


### PR DESCRIPTION
## Summary
- store queued file writes in a fixed-size ring buffer instead of std::queue to avoid heap allocations that could crash the web server during saves
- add overflow handling and adjust pending-count logging for the new buffer implementation

## Testing
- ⚠️ `pio run` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db272d4acc832e8fcd5de2bd66c8de