### PR TITLE
Fix logging expression in FileWriteService queue message

### DIFF
--- a/src/services/FileWriteService.cpp
+++ b/src/services/FileWriteService.cpp
@@ -83,7 +83,7 @@ void FileWriteService::enqueue(const String &path, const String &contents) {
   m_tasks[m_tail].contents = contents;
   m_tail = (m_tail + 1) % kMaxQueueLength;
   m_count++;
-  Serial.println(String(F("[FS] Enqueued write for ")) + path + F(" (queue=")) +
+  Serial.println(String(F("[FS] Enqueued write for ")) + path + F(" (queue=") +
                  String(m_count + (m_busy ? 1 : 0)) + F(")"));
 }
 


### PR DESCRIPTION
## Summary
- correct the queue size log message in FileWriteService so it compiles

## Testing
- not run (platformio CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db28327f80832eb707ffa3761d47d9