### PR TITLE
Fix IO snapshot handler stack usage

### DIFF
--- a/src/services/WebApi.cpp
+++ b/src/services/WebApi.cpp
@@ -145,8 +145,16 @@ void WebApi::handleIoSnapshot() {
                   "{\"error\":\"io unavailable\"}");
     return;
   }
-  StaticJsonDocument<4096> doc;
+  DynamicJsonDocument doc(4096);
   m_io->snapshot(doc);
+  if (doc.overflowed()) {
+    if (m_logger) {
+      m_logger->error("IO snapshot JSON overflow");
+    }
+    m_server.send(500, "application/json",
+                  "{\"error\":\"snapshot too large\"}");
+    return;
+  }
   String response;
   serializeJson(doc, response);
   m_server.send(200, "application/json", response);


### PR DESCRIPTION
## Summary
- allocate the IO snapshot JSON document on the heap to avoid overflowing the ESP8266 handler stack
- emit an explicit error when the snapshot does not fit in the allocated buffer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb754f004832eaa8c9ed592249bc2