### PR TITLE
Adjust binary DMM binary display layout

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -152,8 +152,8 @@
     .binary-caption{text-transform:uppercase; letter-spacing:.2em; font-size:10px; color:#637186}
     .binary-grid{display:grid; grid-template-columns: repeat(auto-fit, minmax(32px,1fr)); gap:8px 10px; justify-items:center; width:100%; max-width:260px}
     .binary-empty{grid-column:1/-1; font-size:12px; color:#5f6b7c; letter-spacing:.05em; text-transform:uppercase}
-    .binary-cell{display:flex; flex-direction:column; align-items:center; gap:4px}
-    .binary-bit{width:100%; padding:6px 0; border-radius:6px; background:#0b1623; border:1px solid #1f2a3a; font-size:14px; font-weight:600; color:#c7d2e2; box-shadow: inset 0 1px 0 rgba(255,255,255,.05); text-align:center}
+    .binary-cell{display:flex; flex-direction:row; align-items:center; gap:6px}
+    .binary-bit{padding:6px 10px; border-radius:6px; background:#0b1623; border:1px solid #1f2a3a; font-size:14px; font-weight:600; color:#c7d2e2; box-shadow: inset 0 1px 0 rgba(255,255,255,.05); text-align:center}
     .binary-bit.on{background:linear-gradient(180deg, rgba(126,241,198,.35) 0%, rgba(59,208,152,.35) 100%); color:#bff6dd; border-color:#2c4a3b}
     .binary-bit-label{font-size:9px; color:#516072; text-transform:uppercase; letter-spacing:.1em}
     .binary-meta{font-size:11px; color:#8793a3; text-align:center}


### PR DESCRIPTION
## Summary
- display binary DMM bits and labels on the same line by switching the flex layout to a row
- tweak binary bit padding to keep the inline layout legible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc4e49a9f0832e8cd2899947f1e2bd