### PR TITLE
Remove exponent labels from DVM binary display

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -150,12 +150,11 @@
     .binary-readout{display:flex; flex-direction:column; gap:4px; align-items:center; font-size:12px; color:var(--sub)}
     .binary-value{font-size:32px; font-weight:600; letter-spacing:1px; color:#7ef1c6}
     .binary-caption{text-transform:uppercase; letter-spacing:.2em; font-size:10px; color:#637186}
-    .binary-grid{display:grid; grid-template-columns: repeat(auto-fit, minmax(32px,1fr)); gap:8px 10px; justify-items:center; width:100%; max-width:260px}
-    .binary-empty{grid-column:1/-1; font-size:12px; color:#5f6b7c; letter-spacing:.05em; text-transform:uppercase}
-    .binary-cell{display:flex; flex-direction:row; align-items:center; gap:6px}
+    .binary-grid{display:flex; flex-wrap:wrap; gap:6px; justify-content:center; width:100%; max-width:260px}
+    .binary-empty{flex:1 0 100%; font-size:12px; color:#5f6b7c; letter-spacing:.05em; text-transform:uppercase; text-align:center}
+    .binary-cell{display:flex; align-items:center; justify-content:center}
     .binary-bit{padding:6px 10px; border-radius:6px; background:#0b1623; border:1px solid #1f2a3a; font-size:14px; font-weight:600; color:#c7d2e2; box-shadow: inset 0 1px 0 rgba(255,255,255,.05); text-align:center}
     .binary-bit.on{background:linear-gradient(180deg, rgba(126,241,198,.35) 0%, rgba(59,208,152,.35) 100%); color:#bff6dd; border-color:#2c4a3b}
-    .binary-bit-label{font-size:9px; color:#516072; text-transform:uppercase; letter-spacing:.1em}
     .binary-meta{font-size:11px; color:#8793a3; text-align:center}
     .gauge{width:100%; max-width:260px}
     #dmm-gauge-svg{width:100%; height:auto}
@@ -514,11 +513,7 @@
         const bitEl = document.createElement('div');
         bitEl.className = 'binary-bit' + (bit === '1' ? ' on' : '');
         bitEl.textContent = bit;
-        const label = document.createElement('div');
-        label.className = 'binary-bit-label';
-        label.textContent = '2^' + bitIndex;
         cell.appendChild(bitEl);
-        cell.appendChild(label);
         grid.appendChild(cell);
       }
       meta.textContent = `Bits : ${bits} • Arrondi : ${rounded}`;


### PR DESCRIPTION
## Summary
- remove the 2^ exponent labels from the DVM binary readout
- place the binary bits side by side with a flex-based layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc503b82c4832e8cb00f28e2e59004