### PR TITLE
Fix binary DMM grid alignment

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -150,7 +150,7 @@
     .binary-readout{display:flex; flex-direction:column; gap:4px; align-items:center; font-size:12px; color:var(--sub)}
     .binary-value{font-size:32px; font-weight:600; letter-spacing:1px; color:#7ef1c6}
     .binary-caption{text-transform:uppercase; letter-spacing:.2em; font-size:10px; color:#637186}
-    .binary-grid{display:flex; flex-wrap:wrap; gap:6px; justify-content:center; width:100%; max-width:260px}
+    .binary-grid{display:flex; flex-wrap:wrap; gap:6px; justify-content:center; width:100%; max-width:320px}
     .binary-empty{flex:1 0 100%; font-size:12px; color:#5f6b7c; letter-spacing:.05em; text-transform:uppercase; text-align:center}
     .binary-cell{display:flex; align-items:center; justify-content:center}
     .binary-bit{padding:6px 10px; border-radius:6px; background:#0b1623; border:1px solid #1f2a3a; font-size:14px; font-weight:600; color:#c7d2e2; box-shadow: inset 0 1px 0 rgba(255,255,255,.05); text-align:center}


### PR DESCRIPTION
## Summary
- allow the binary grid in the DMM view to grow wider so all eight bits stay on a single row

## Testing
- no automated tests were run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dc51e89174832e891078af6a62a949