### PR TITLE
Refactor oscilloscope layout

### DIFF
--- a/data/scope.html
+++ b/data/scope.html
@@ -2,11 +2,170 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Oscilloscope – MiniLabo</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Oscilloscope</h1>
-  <p>L’oscilloscope n’est pas encore implémenté dans cette version.</p>
+  <main class="scope-page">
+    <section class="scope-control-panel" aria-labelledby="scope-title">
+      <h1 id="scope-title">Oscilloscope</h1>
+      <div class="control-group">
+        <label for="timebase">Base de temps</label>
+        <select id="timebase" aria-label="Base de temps">
+          <option value="0.5">5 µs/div</option>
+          <option value="1" selected>10 µs/div</option>
+          <option value="2">20 µs/div</option>
+          <option value="4">50 µs/div</option>
+          <option value="8">100 µs/div</option>
+        </select>
+      </div>
+      <fieldset class="control-group channels">
+        <legend>Canaux affichés</legend>
+        <div class="channel-control" data-channel="ch1">
+          <label>
+            <input type="checkbox" checked data-channel-toggle> Canal 1
+          </label>
+          <label class="channel-color">
+            Couleur
+            <input type="color" value="#3dff70" data-channel-color aria-label="Couleur du canal 1">
+          </label>
+        </div>
+        <div class="channel-control" data-channel="ch2">
+          <label>
+            <input type="checkbox" checked data-channel-toggle> Canal 2
+          </label>
+          <label class="channel-color">
+            Couleur
+            <input type="color" value="#ffd74d" data-channel-color aria-label="Couleur du canal 2">
+          </label>
+        </div>
+        <div class="channel-control" data-channel="ch3">
+          <label>
+            <input type="checkbox" data-channel-toggle> Canal 3
+          </label>
+          <label class="channel-color">
+            Couleur
+            <input type="color" value="#00d2ff" data-channel-color aria-label="Couleur du canal 3">
+          </label>
+        </div>
+        <div class="channel-control" data-channel="ch4">
+          <label>
+            <input type="checkbox" data-channel-toggle> Canal 4
+          </label>
+          <label class="channel-color">
+            Couleur
+            <input type="color" value="#ff5f85" data-channel-color aria-label="Couleur du canal 4">
+          </label>
+        </div>
+      </fieldset>
+    </section>
+
+    <section class="scope-display-panel">
+      <div class="scope-screen" role="img" aria-label="Affichage de l'oscilloscope">
+        <svg id="scope-display" viewBox="0 0 500 528" xmlns="http://www.w3.org/2000/svg">
+          <g class="scope-grid">
+            <rect x="0" y="0" width="500" height="500"></rect>
+            <path class="grid-lines" d="M0,0 V500 M50,0 V500 M100,0 V500 M150,0 V500 M200,0 V500 M250,0 V500 M300,0 V500 M350,0 V500 M400,0 V500 M450,0 V500 M500,0 V500 M0,0 H500 M0,50 H500 M0,100 H500 M0,150 H500 M0,200 H500 M0,250 H500 M0,300 H500 M0,350 H500 M0,400 H500 M0,450 H500 M0,500 H500"></path>
+            <line class="scope-axis" x1="0" y1="250" x2="500" y2="250"></line>
+            <line class="scope-axis" x1="250" y1="0" x2="250" y2="500"></line>
+            <path class="sub-division" d="M0,245 V255 M10,245 V255 M20,245 V255 M30,245 V255 M40,245 V255 M50,245 V255 M60,245 V255 M70,245 V255 M80,245 V255 M90,245 V255 M100,245 V255 M110,245 V255 M120,245 V255 M130,245 V255 M140,245 V255 M150,245 V255 M160,245 V255 M170,245 V255 M180,245 V255 M190,245 V255 M200,245 V255 M210,245 V255 M220,245 V255 M230,245 V255 M240,245 V255 M250,245 V255 M260,245 V255 M270,245 V255 M280,245 V255 M290,245 V255 M300,245 V255 M310,245 V255 M320,245 V255 M330,245 V255 M340,245 V255 M350,245 V255 M360,245 V255 M370,245 V255 M380,245 V255 M390,245 V255 M400,245 V255 M410,245 V255 M420,245 V255 M430,245 V255 M440,245 V255 M450,245 V255 M460,245 V255 M470,245 V255 M480,245 V255 M490,245 V255 M500,245 V255 M245,0 H255 M245,10 H255 M245,20 H255 M245,30 H255 M245,40 H255 M245,50 H255 M245,60 H255 M245,70 H255 M245,80 H255 M245,90 H255 M245,100 H255 M245,110 H255 M245,120 H255 M245,130 H255 M245,140 H255 M245,150 H255 M245,160 H255 M245,170 H255 M245,180 H255 M245,190 H255 M245,200 H255 M245,210 H255 M245,220 H255 M245,230 H255 M245,240 H255 M245,250 H255 M245,260 H255 M245,270 H255 M245,280 H255 M245,290 H255 M245,300 H255 M245,310 H255 M245,320 H255 M245,330 H255 M245,340 H255 M245,350 H255 M245,360 H255 M245,370 H255 M245,380 H255 M245,390 H255 M245,400 H255 M245,410 H255 M245,420 H255 M245,430 H255 M245,440 H255 M245,450 H255 M245,460 H255 M245,470 H255 M245,480 H255 M245,490 H255 M245,500 H255"></path>
+            <line class="reference-line" x1="0" y1="250" x2="500" y2="250"></line>
+            <text class="reference-label" x="6" y="244">0 V (réf.)</text>
+          </g>
+          <g id="scope-traces"></g>
+          <g class="scope-legend">
+            <text x="10" y="522" id="voltage-scale">1 V/div</text>
+            <text x="300" y="522" id="time-scale">10 µs/div</text>
+          </g>
+        </svg>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const timebaseSelect = document.getElementById('timebase');
+    const traceContainer = document.getElementById('scope-traces');
+    const timeScaleLabel = document.getElementById('time-scale');
+
+    const channels = [
+      { id: 'ch1', amplitude: 70, offset: 0, phase: 0, color: '#3dff70', frequency: 1.2 },
+      { id: 'ch2', amplitude: 45, offset: -40, phase: Math.PI / 2, color: '#ffd74d', frequency: 0.8 },
+      { id: 'ch3', amplitude: 55, offset: 50, phase: Math.PI, color: '#00d2ff', frequency: 1.6 },
+      { id: 'ch4', amplitude: 35, offset: -90, phase: Math.PI / 4, color: '#ff5f85', frequency: 2.3 }
+    ];
+
+    const channelControls = document.querySelectorAll('.channel-control');
+
+    channelControls.forEach(control => {
+      const channelId = control.dataset.channel;
+      const channel = channels.find(ch => ch.id === channelId);
+      const toggle = control.querySelector('[data-channel-toggle]');
+      const colorInput = control.querySelector('[data-channel-color]');
+
+      colorInput.value = channel.color;
+
+      toggle.addEventListener('change', () => {
+        updateChannelVisibility(channelId, toggle.checked);
+      });
+
+      colorInput.addEventListener('input', () => {
+        channel.color = colorInput.value;
+        const trace = document.getElementById(`trace-${channelId}`);
+        if (trace) {
+          trace.setAttribute('stroke', channel.color);
+        }
+      });
+    });
+
+    timebaseSelect.addEventListener('change', () => {
+      const label = timebaseSelect.options[timebaseSelect.selectedIndex].textContent;
+      timeScaleLabel.textContent = label;
+      drawTraces();
+    });
+
+    function updateChannelVisibility(channelId, visible) {
+      const trace = document.getElementById(`trace-${channelId}`);
+      if (trace) {
+        trace.style.display = visible ? 'block' : 'none';
+      }
+    }
+
+    function drawTraces() {
+      const width = 500;
+      const height = 500;
+      const centerY = height / 2;
+      const subdivisions = 500;
+      const timeScale = parseFloat(timebaseSelect.value);
+
+      channels.forEach(channel => {
+        const control = document.querySelector(`.channel-control[data-channel="${channel.id}"] [data-channel-toggle]`);
+        const isEnabled = control && control.checked;
+
+        let trace = document.getElementById(`trace-${channel.id}`);
+        if (!trace) {
+          trace = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          trace.id = `trace-${channel.id}`;
+          trace.setAttribute('fill', 'none');
+          trace.setAttribute('stroke-width', '2');
+          traceContainer.appendChild(trace);
+        }
+
+        const frequency = channel.frequency * timeScale;
+        let d = '';
+        for (let x = 0; x <= subdivisions; x++) {
+          const t = (x / subdivisions) * Math.PI * 2 * frequency;
+          const y = centerY - (channel.amplitude * Math.sin(t + channel.phase)) + channel.offset;
+          d += `${x === 0 ? 'M' : 'L'}${(x / subdivisions) * width},${y.toFixed(2)} `;
+        }
+
+        trace.setAttribute('d', d.trim());
+        trace.setAttribute('stroke', channel.color);
+        trace.style.display = isEnabled ? 'block' : 'none';
+      });
+    }
+
+    drawTraces();
+  </script>
 </body>
 </html>

--- a/data/styles.css
+++ b/data/styles.css
@@ -5,40 +5,196 @@ body {
   background-color: #f8f8f8;
   color: #222;
 }
+
 h1 {
   margin-top: 0;
 }
+
 nav {
   margin-bottom: 1em;
 }
+
 nav a {
   margin-right: 1em;
   text-decoration: none;
   color: #0066cc;
 }
+
 nav a:hover {
   text-decoration: underline;
 }
+
 table {
   border-collapse: collapse;
   width: 100%;
   max-width: 600px;
   background-color: #fff;
 }
-th, td {
+
+th,
+td {
   border: 1px solid #ccc;
   padding: 0.5em;
   text-align: left;
 }
+
 th {
   background-color: #eee;
 }
+
 button {
   padding: 0.4em 1em;
   margin-top: 1em;
   cursor: pointer;
 }
+
 textarea {
   width: 100%;
   max-width: 800px;
+}
+
+/* Oscilloscope layout */
+.scope-page {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.scope-control-panel {
+  flex: 1 1 260px;
+  max-width: 320px;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.scope-control-panel .control-group,
+.scope-control-panel .channel-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  gap: 0.75rem;
+}
+
+.scope-control-panel label {
+  font-weight: 600;
+}
+
+.scope-control-panel select,
+.scope-control-panel input[type="color"] {
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.95rem;
+  background-color: #f9f9f9;
+}
+
+.scope-control-panel input[type="checkbox"] {
+  transform: scale(1.1);
+  margin-right: 0.5rem;
+}
+
+.channels {
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.channels legend {
+  padding: 0 0.5rem;
+  font-weight: 700;
+}
+
+.channel-control {
+  border-bottom: 1px solid #e9e9e9;
+  padding-bottom: 0.75rem;
+}
+
+.channel-control:last-of-type {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.channel-color {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.scope-display-panel {
+  flex: 1 1 420px;
+}
+
+.scope-screen {
+  background: radial-gradient(circle at 50% 30%, #1a2333 0%, #0c121d 60%, #050910 100%);
+  padding: 1.5rem;
+  border-radius: 20px;
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.scope-screen svg {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 500 / 528;
+  display: block;
+}
+
+.scope-grid rect {
+  fill: rgba(7, 12, 19, 0.85);
+  stroke: #293242;
+  stroke-width: 2;
+}
+
+.scope-grid .grid-lines {
+  stroke: rgba(103, 176, 255, 0.25);
+  stroke-width: 1;
+}
+
+.scope-grid .scope-axis {
+  stroke: rgba(112, 216, 255, 0.55);
+  stroke-width: 2;
+}
+
+.scope-grid .sub-division {
+  stroke: rgba(103, 176, 255, 0.2);
+  stroke-width: 1;
+}
+
+.reference-line {
+  stroke: rgba(255, 82, 82, 0.8);
+  stroke-width: 1.4;
+  stroke-dasharray: 6 6;
+}
+
+.reference-label {
+  fill: rgba(255, 115, 115, 0.9);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+#scope-traces path {
+  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.35));
+}
+
+.scope-legend text {
+  fill: rgba(225, 236, 255, 0.85);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .scope-page {
+    flex-direction: column;
+  }
+
+  .scope-control-panel,
+  .scope-display-panel {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the oscilloscope placeholder with a full layout that mirrors the reference screen ratio
- add selectors for timebase, visible channels, and per-channel trace colors
- restyle the scope page to highlight the SVG display while keeping controls compact

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68dc5bb7aac8832eaea3b6f849b942c5