### PR TITLE
Déplace l'indicateur Live/Acquisition en bas du cadran de l'oscilloscope

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -236,16 +236,10 @@
       position:relative;
       display:flex;
     }
-    .scope-head{
-      display:flex; justify-content:space-between; align-items:center; padding:10px 14px; border-bottom:1px solid #162235; background:linear-gradient(180deg,#09111d 0%, #060b14 100%);
-      font-size:12px; color:#b7c3d1;
-      gap:12px;
-    }
-    .scope-head-right{display:flex; align-items:center; gap:10px}
     .scope-meta{display:flex; gap:10px; align-items:center}
     .scope-led{width:8px;height:8px;border-radius:50%; background:#67e8f9; box-shadow:0 0 10px rgba(76,195,255,.6)}
     .scope-body{display:flex; width:100%; min-height:230px}
-    .scope-screen{flex:1 1 auto; position:relative; min-height:220px; display:flex; align-items:center; justify-content:center; padding:14px}
+    .scope-screen{flex:1 1 auto; position:relative; min-height:220px; display:flex; flex-direction:column; align-items:center; justify-content:flex-start; padding:14px; gap:12px}
     .scope-display{width:100%; max-width:520px}
     #scope-display{width:100%; height:auto; display:block}
     #scope-display .scope-grid rect{fill:#050910; stroke:#1b2d42; stroke-width:2}
@@ -261,6 +255,8 @@
     #scope-ref-popup{top:14px; left:18px}
     #scope-scale-popup{bottom:18px; left:18px}
     #scope-zero-popup{top:50%; left:18px; transform:translateY(-50%)}
+    .scope-status{display:flex; justify-content:space-between; align-items:center; gap:12px; font-size:12px; color:#b7c3d1; background:linear-gradient(180deg,#09111d 0%, #060b14 100%); border:1px solid #162235; border-radius:10px; padding:10px 14px; width:100%; margin-top:auto; align-self:stretch}
+    .scope-status-right{display:flex; align-items:center; gap:10px}
     .scope-controls{
       flex:0 0 200px;
       border-left:1px solid #162235;
@@ -474,14 +470,6 @@
         <h2>Oscilloscope <span class="badge" id="scope-chan">CH1</span> <span class="pill blue" id="scope-timebase">— ms/div</span></h2>
         <div class="content single">
           <div class="scope-wrap">
-            <div class="scope-head">
-              <div class="scope-meta">
-                <span class="scope-led"></span>
-                <span>Live</span>
-                <span class="info-label" id="scope-trace-info" data-tooltip="—" tabindex="0">Trace <span class="info-icon" aria-hidden="true">i</span></span>
-              </div>
-              <div class="scope-head-right info-label" id="scope-meta" data-tooltip="—" tabindex="0">Acquisition <span class="info-icon" aria-hidden="true">i</span></div>
-            </div>
             <div class="scope-body">
               <div class="scope-screen" id="scope-screen">
                 <div class="scope-display" role="img" aria-label="Affichage oscilloscope">
@@ -509,6 +497,14 @@
                   <div class="scope-popup info-label" id="scope-zero-popup" data-tooltip="Ligne 0 V, utilisez l’offset pour centrer le signal." tabindex="0">0 V <span class="info-icon" aria-hidden="true">i</span></div>
                   <div class="scope-popup info-label" id="scope-scale-popup" data-tooltip="—" tabindex="0">Échelle <span class="info-icon" aria-hidden="true">i</span></div>
                 </div>
+                <div class="scope-status">
+                  <div class="scope-meta">
+                    <span class="scope-led"></span>
+                    <span>Live</span>
+                    <span class="info-label" id="scope-trace-info" data-tooltip="—" tabindex="0">Trace <span class="info-icon" aria-hidden="true">i</span></span>
+                  </div>
+                  <div class="scope-status-right info-label" id="scope-meta" data-tooltip="—" tabindex="0">Acquisition <span class="info-icon" aria-hidden="true">i</span></div>
+                </div>
               </div>
               <div class="scope-controls">
                 <div class="scope-control">
@@ -529,7 +525,6 @@
               </div>
             </div>
           </div>
-          <div class="hint">Affichage 1 canal. Utilise la base de temps et l’échelle verticale pour caler ton signal, et configure la trace pour changer de canal.</div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- repositionné les informations Live/Acquisition sous l'affichage de l'oscilloscope
- ajusté le style associé pour un affichage plein largeur en bas du cadran
- retiré le texte d'aide « Affichage 1 canal » redondant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc61c32cf8832ebf9050a4c6b2e3d0