### PR TITLE
Add oscilloscope API endpoint

### DIFF
--- a/data/scope.json
+++ b/data/scope.json
@@ -1,6 +1,9 @@
 {
-  "enabled": false,
+  "enabled": true,
   "channel": "CH1",
+  "io": "A0",
+  "label": "CH1",
+  "display": "CH1 — A0",
   "timebase": 10,
   "vdiv": 1.0,
   "offset": 0.0

--- a/src/services/WebApi.h
+++ b/src/services/WebApi.h
@@ -43,6 +43,7 @@ private:
   void handleGetConfig();
   void handlePutConfig();
   void handleDmm();
+  void handleScope();
   void handleFuncGen();
   void handleLogsTail();
   void handleWifiScan();


### PR DESCRIPTION
## Summary
- add a /api/scope endpoint that streams live samples from configured IO channels
- parse scope configuration to derive channel metadata and emit it with captured data
- provide default metadata for CH1 in scope.json so the UI can present the live trace label

## Testing
- not run (PlatformIO CLI is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd22c647fc832e85c8b35cb07d462f