### PR TITLE
Refine function generator layout

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -124,8 +124,11 @@
 
     /* FUNCGEN styles */
     #card-func .content{
-      padding:18px;
+      padding:16px;
       height:calc(100% - 52px);
+      display:flex;
+      align-items:stretch;
+      justify-content:stretch;
     }
     .func-layout{
       width:100%;
@@ -133,37 +136,43 @@
       border-collapse:separate;
       border-spacing:6px;
       table-layout:fixed;
+      margin:0;
     }
-    .func-layout .func-col-label{width:8%}
-    .func-layout .func-col-main{width:62%}
+    #card-func .content > .func-layout{flex:1 1 auto}
+    .func-layout .func-col-label{width:9%}
+    .func-layout .func-col-main{width:61%}
     .func-layout .func-col-side{width:30%}
     .func-layout td{
       border:1px solid #1b2636;
       border-radius:12px;
-      background:rgba(12,18,30,.85);
-      padding:12px;
+      background:rgba(12,18,30,.82);
+      padding:10px 12px;
       vertical-align:top;
     }
-    .func-layout .func-label{
-      width:56px;
-      text-align:center;
-      font-size:18px;
-      font-weight:600;
-      color:#c8d4e8;
-      letter-spacing:.2em;
-      text-transform:uppercase;
-      background:rgba(12,18,30,.65);
+    .func-layout .func-param-cell{
+      padding:0;
+      background:none;
+      border:none;
       display:flex;
       align-items:center;
       justify-content:center;
     }
-    .func-layout .func-label-sub{font-size:18px; font-variant-numeric:tabular-nums}
+    .func-param-cell .func-param-btn{
+      width:100%;
+      height:100%;
+      min-width:0;
+      min-height:0;
+      border-radius:12px;
+      box-shadow: inset 0 0 0 1px rgba(45,65,92,.55), 0 6px 14px rgba(0,0,0,.35);
+      cursor:default;
+      pointer-events:none;
+    }
+    .func-param-cell .func-param-btn .symbol{font-size:18px}
     .func-meta-cell{
       text-align:center;
       background:linear-gradient(160deg, rgba(13,19,30,.9) 0%, rgba(12,18,29,.8) 100%);
     }
     .func-meta-cell .func-summary{justify-content:center; font-size:13px; color:#d0def6}
-    .func-meta-cell .func-summary-empty{width:100%; text-align:center}
     .func-output-cell{
       background:linear-gradient(160deg, rgba(15,23,35,.9) 0%, rgba(12,18,28,.8) 100%);
     }
@@ -175,10 +184,15 @@
     .func-output-box .pill{align-self:flex-start}
     .func-display-cell{padding:0; background:none}
     .func-display{height:100%; border-radius:16px}
-    .func-adjust-cell{display:flex; align-items:center; justify-content:center; background:rgba(12,18,30,.75)}
-    .func-adjust-cell .func-digit-btn{min-width:64px; min-height:64px}
-    .func-adjust-cell.top{border-bottom-left-radius:0}
-    .func-adjust-cell.bottom{border-top-left-radius:0}
+    .func-adjust-cell{
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      background:rgba(12,18,30,.75);
+      padding:12px;
+    }
+    .func-adjust-stack{display:flex; flex-direction:column; gap:8px; width:100%; height:100%}
+    .func-adjust-stack .func-digit-btn{min-width:0; width:100%; min-height:52px; flex:1 1 auto}
     .func-param-zone{display:flex; flex-direction:column; gap:12px; align-items:center}
     .func-wave-cell{background:linear-gradient(160deg, rgba(12,18,30,.82) 0%, rgba(10,14,22,.9) 100%); padding:12px 10px}
     .func-wave-list{display:flex; gap:8px; flex-wrap:wrap; justify-content:center}
@@ -189,8 +203,9 @@
     @media (max-width: 980px){
       #card-func .content{padding:12px}
       .func-layout{border-spacing:4px}
-      .func-layout td{padding:10px}
-      .func-layout .func-label{width:46px; font-size:16px}
+      .func-layout td{padding:8px 10px}
+      .func-param-cell .func-param-btn{padding:10px}
+      .func-param-cell .func-param-btn .symbol{font-size:16px}
     }
     .func-wave-btn{
       border:none;
@@ -339,18 +354,20 @@
     }
     .func-summary{
       display:flex;
-      flex-wrap:wrap;
-      gap:8px;
       align-items:center;
-      justify-content:center;
-      font-size:13px;
+      flex-wrap:nowrap;
+      gap:16px;
+      font-size:12px;
       color:#d0def6;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
+      min-height:32px;
+      flex:1 1 auto;
+      min-width:0;
     }
-    .func-summary-item{display:flex; gap:6px; align-items:baseline; background:rgba(14,22,35,.7); padding:6px 10px; border-radius:8px; border:1px solid rgba(40,56,82,.5)}
-    .func-summary-item .label{letter-spacing:.12em; text-transform:uppercase; font-size:10px; color:#7f8ea8}
-    .func-summary-item .value{font-weight:600; color:#f0f7ff; font-size:13px}
-    .func-summary-item .detail{font-size:11px; color:#63c7ff}
-    .func-summary-empty{opacity:.6; font-style:italic; padding:6px 0}
+    #func-hint,
+    .func-output-type{display:none}
     .func-hint{
       font-size:12px;
       color:#6e7f99;
@@ -676,7 +693,12 @@
             </colgroup>
             <tbody>
               <tr>
-                <td class="func-label">U</td>
+                <td class="func-param-cell">
+                  <span class="func-param-btn active">
+                    <span class="symbol">U</span>
+                    <span class="sr-only">Sortie sélectionnée</span>
+                  </span>
+                </td>
                 <td class="func-meta-cell">
                   <div class="func-summary" id="func-summary" aria-live="polite">—</div>
                 </td>
@@ -691,7 +713,12 @@
                 </td>
               </tr>
               <tr>
-                <td class="func-label func-label-sub">U<sub>0</sub></td>
+                <td class="func-param-cell">
+                  <span class="func-param-btn active">
+                    <span class="symbol">U<sub>0</sub></span>
+                    <span class="sr-only">Valeur courante</span>
+                  </span>
+                </td>
                 <td class="func-display-cell" rowspan="2">
                   <div class="func-display">
                     <div class="func-main-value">
@@ -701,18 +728,28 @@
                     </div>
                   </div>
                 </td>
-                <td class="func-adjust-cell top">
-                  <button class="func-digit-btn" id="func-plus" type="button" aria-label="Augmenter la valeur" title="Augmenter">+</button>
+                <td class="func-adjust-cell" rowspan="2">
+                  <div class="func-adjust-stack">
+                    <button class="func-digit-btn" id="func-plus" type="button" aria-label="Augmenter la valeur" title="Augmenter">+</button>
+                    <button class="func-digit-btn" id="func-minus" type="button" aria-label="Diminuer la valeur" title="Diminuer">−</button>
+                  </div>
                 </td>
               </tr>
               <tr>
-                <td class="func-label">F</td>
-                <td class="func-adjust-cell bottom">
-                  <button class="func-digit-btn" id="func-minus" type="button" aria-label="Diminuer la valeur" title="Diminuer">−</button>
+                <td class="func-param-cell">
+                  <span class="func-param-btn active">
+                    <span class="symbol">F</span>
+                    <span class="sr-only">Fréquence</span>
+                  </span>
                 </td>
               </tr>
               <tr>
-                <td class="func-label">D</td>
+                <td class="func-param-cell">
+                  <span class="func-param-btn active">
+                    <span class="symbol">D</span>
+                    <span class="sr-only">Paramètres</span>
+                  </span>
+                </td>
                 <td class="func-wave-cell">
                   <div class="func-param-zone">
                     <div class="func-params" id="func-param-buttons"></div>
@@ -1588,39 +1625,25 @@
       if(!funcSummary) return;
       const ctx = getFuncContext();
       const profile = ctx.profile;
-      funcSummary.innerHTML = '';
+      funcSummary.textContent = '';
       if(!profile || !Array.isArray(profile.parameters)){
         funcSummary.textContent = '—';
         return;
       }
+      const parts = [];
       profile.parameters.forEach(param=>{
         if(param === funcState.currentParam) return;
         const def = FUNC_PARAM_DEFS[param];
         if(!def) return;
         const formatted = formatParam(param, ctx);
-        const item = document.createElement('span');
-        item.className = 'func-summary-item';
-        const label = document.createElement('span');
-        label.className = 'label';
-        label.textContent = def.label;
-        const value = document.createElement('span');
-        value.className = 'value';
-        value.textContent = formatted.main + (formatted.unit ? ' ' + formatted.unit : '');
-        item.append(label, value);
+        const mainValue = formatted.main + (formatted.unit ? ' ' + formatted.unit : '');
+        let piece = (def.label || param) + ' : ' + mainValue;
         if(formatted.secondary){
-          const detail = document.createElement('span');
-          detail.className = 'detail';
-          detail.textContent = formatted.secondary;
-          item.append(detail);
+          piece += ' (' + formatted.secondary + ')';
         }
-        funcSummary.appendChild(item);
+        parts.push(piece);
       });
-      if(!funcSummary.children.length){
-        const empty = document.createElement('span');
-        empty.className = 'func-summary-empty';
-        empty.textContent = '—';
-        funcSummary.appendChild(empty);
-      }
+      funcSummary.textContent = parts.length ? parts.join(' • ') : '—';
     }
     function renderFuncParamButtons(profile){
       if(!funcParamButtons) return;


### PR DESCRIPTION
## Summary
- adjust the function generator table to fill the card, replace the left labels with static param badges, and stack the increment/decrement controls
- streamline the generator summary to a single-line readout and hide the hint/output type chrome for a cleaner look

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd815e7194832eaf823c4d5c504f09