### PR TITLE
Move function generator parameter buttons into main column

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -704,24 +704,7 @@
             <tbody>
               <tr>
                 <td rowspan="4" colspan="1" valign="top">
-                  <div class="func-param-stack">
-                    <button class="func-param-btn active" type="button">
-                      <span class="symbol">U</span>
-                      <span class="sr-only">Sortie sélectionnée</span>
-                    </button>
-                    <button class="func-param-btn active" type="button">
-                      <span class="symbol">U<sub>0</sub></span>
-                      <span class="sr-only">Valeur courante</span>
-                    </button>
-                    <button class="func-param-btn active" type="button">
-                      <span class="symbol">F</span>
-                      <span class="sr-only">Fréquence</span>
-                    </button>
-                    <button class="func-param-btn active" type="button">
-                      <span class="symbol">D</span>
-                      <span class="sr-only">Paramètres</span>
-                    </button>
-                  </div>
+                  <div class="func-params" id="func-param-buttons"></div>
                 </td>
                 <td class="func-meta-cell">
                   <div class="func-summary empty" id="func-summary" aria-live="polite" role="list">
@@ -759,7 +742,6 @@
               <tr>
                 <td class="func-wave-cell">
                   <div class="func-param-zone">
-                    <div class="func-params" id="func-param-buttons"></div>
                     <div class="func-wave-list" id="func-wave-list" role="radiogroup" aria-label="Forme d’onde"></div>
                   </div>
                 </td>


### PR DESCRIPTION
## Summary
- replace the static function generator parameter stack with the dynamic parameter button container
- remove the duplicate parameter button container from the waveform area

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd8c0d2efc832eb4dad498e0679984