### PR TITLE
Adjust function generator summary layout

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -163,8 +163,8 @@
     .func-output-box .func-output-name{font-size:18px; font-weight:600; letter-spacing:.03em}
     .func-output-box .func-output-type{font-size:12px; letter-spacing:.18em; color:#58e4ff; text-transform:uppercase}
     .func-output-box .pill{align-self:flex-start}
-    .func-display-cell{padding:0; background:none}
-    .func-display{height:100%; border-radius:16px}
+    .func-display-cell{padding:0; background:none; height:100%;}
+    .func-display{height:100%; min-height:260px; border-radius:16px; width:100%;}
     .func-adjust-cell{
       display:flex;
       align-items:center;
@@ -279,14 +279,15 @@
       position:relative;
       border:none;
       background:linear-gradient(150deg, rgba(16,23,35,.85) 0%, rgba(10,15,24,1) 100%);
-      padding:10px 16px;
+      padding:10px 14px;
       border-radius:12px;
       cursor:pointer;
       color:#c9d7f1;
       display:flex;
       align-items:center;
       justify-content:center;
-      min-width:76px;
+      min-width:68px;
+      flex:1 0 68px;
       min-height:48px;
       box-shadow: inset 0 0 0 1px rgba(45,65,92,.55), 0 10px 24px rgba(0,0,0,.4);
       transition:transform .2s ease, box-shadow .2s ease, background .2s ease;
@@ -325,26 +326,30 @@
     .func-param-btn:focus-visible{outline:2px solid rgba(76,195,255,.6); outline-offset:4px}
     .func-summary{
       display:flex;
-      flex-direction:column;
-      align-items:flex-start;
+      flex-direction:row;
+      align-items:center;
       gap:6px;
       font-size:12px;
       color:#d0def6;
       min-height:48px;
       flex:1 1 auto;
       min-width:0;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
     }
     .func-summary.empty{justify-content:center; align-items:center; color:#64748b}
     .func-summary-item{
-      display:flex;
-      flex-wrap:wrap;
+      display:inline-flex;
       align-items:baseline;
-      gap:4px;
+      gap:6px;
     }
     .func-summary-item.current .func-summary-value{color:#58e4ff}
+    .func-summary-label{font-size:12px; color:#7ea6d9; text-transform:uppercase; letter-spacing:.16em}
     .func-summary-value{font-size:14px; letter-spacing:.04em; color:#e4f1ff; font-weight:600}
     .func-summary-value .unit{font-size:11px; margin-left:3px; letter-spacing:.12em; text-transform:uppercase; color:#7fbfff}
     .func-summary-secondary{font-size:11px; color:#7a8aa6; opacity:.9}
+    .func-summary-separator{opacity:.4; font-size:11px; color:#7a8aa6; margin:0 2px;}
     .func-summary-empty{opacity:.7; font-style:italic}
     #func-hint,
     .func-output-type{display:none}
@@ -678,7 +683,7 @@
                 </td>
                 <td class="func-meta-cell">
                   <div class="func-summary empty" id="func-summary" aria-live="polite" role="list">
-                    <div class="func-summary-item func-summary-empty" role="listitem">—</div>
+                    <span class="func-summary-item func-summary-empty" role="listitem">—</span>
                   </div>
                 </td>
                 <td class="func-output-cell">
@@ -1586,7 +1591,7 @@
       funcSummary.classList.remove('empty');
       if(!profile || !Array.isArray(profile.parameters) || !profile.parameters.length){
         funcSummary.classList.add('empty');
-        const empty = document.createElement('div');
+        const empty = document.createElement('span');
         empty.className = 'func-summary-item func-summary-empty';
         empty.setAttribute('role','listitem');
         empty.textContent = '—';
@@ -1594,22 +1599,14 @@
         return;
       }
       let hasItem = false;
+      let itemCount = 0;
       profile.parameters.forEach(param=>{
         const def = FUNC_PARAM_DEFS[param];
         if(!def) return;
         const formatted = formatParam(param, ctx);
-        const item = document.createElement('div');
+        const item = document.createElement('span');
         item.className = 'func-summary-item' + (param === funcState.currentParam ? ' current' : '');
         item.setAttribute('role','listitem');
-        const value = document.createElement('span');
-        value.className = 'func-summary-value';
-        value.textContent = formatted.main;
-        if(formatted.unit){
-          const unit = document.createElement('span');
-          unit.className = 'unit';
-          unit.textContent = formatted.unit;
-          value.appendChild(unit);
-        }
         const labelText = def.label || param;
         const mainText = formatted.unit ? `${formatted.main} ${formatted.unit}` : formatted.main;
         let description = `${labelText}: ${mainText}`;
@@ -1619,7 +1616,27 @@
         item.setAttribute('title', description);
         item.setAttribute('aria-label', description);
         item.dataset.param = param;
-        item.append(value);
+        if(itemCount > 0){
+          const separator = document.createElement('span');
+          separator.className = 'func-summary-separator';
+          separator.textContent = '•';
+          separator.setAttribute('aria-hidden', 'true');
+          funcSummary.appendChild(separator);
+        }
+        const label = document.createElement('span');
+        label.className = 'func-summary-label';
+        label.textContent = labelText;
+        item.appendChild(label);
+        const value = document.createElement('span');
+        value.className = 'func-summary-value';
+        value.textContent = formatted.main;
+        if(formatted.unit){
+          const unit = document.createElement('span');
+          unit.className = 'unit';
+          unit.textContent = formatted.unit;
+          value.appendChild(unit);
+        }
+        item.appendChild(value);
         if(formatted.secondary){
           const secondary = document.createElement('span');
           secondary.className = 'func-summary-secondary';
@@ -1628,10 +1645,11 @@
         }
         funcSummary.appendChild(item);
         hasItem = true;
+        itemCount += 1;
       });
       if(!hasItem){
         funcSummary.classList.add('empty');
-        const empty = document.createElement('div');
+        const empty = document.createElement('span');
         empty.className = 'func-summary-item func-summary-empty';
         empty.setAttribute('role','listitem');
         empty.textContent = '—';


### PR DESCRIPTION
## Summary
- keep the function generator display panel height consistent
- compress the parameter summary into a single-line layout with separators and updated styling
- reduce the minimum width of function parameter buttons so the active button no longer feels oversized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd91e1644c832ea18c17d7a995ad80