### PR TITLE
Adjust function generator UI layout

### DIFF
--- a/data/devices.html
+++ b/data/devices.html
@@ -152,6 +152,7 @@
     .func-meta-cell{
       text-align:center;
       background:linear-gradient(160deg, rgba(13,19,30,.9) 0%, rgba(12,18,29,.8) 100%);
+      padding:6px 10px;
     }
     .func-meta-cell .func-summary{justify-content:center; font-size:13px; color:#d0def6}
     .func-output-cell{
@@ -164,7 +165,7 @@
     .func-output-box .func-output-type{font-size:12px; letter-spacing:.18em; color:#58e4ff; text-transform:uppercase}
     .func-output-box .pill{align-self:flex-start}
     .func-display-cell{padding:0; background:none; height:100%;}
-    .func-display{height:100%; min-height:260px; border-radius:16px; width:100%;}
+    .func-display{height:100%; min-height:260px; border-radius:16px; width:100%; display:flex; align-items:stretch;}
     .func-adjust-cell{
       display:flex;
       align-items:center;
@@ -253,6 +254,9 @@
       justify-content:center;
       gap:12px;
       box-shadow: inset 0 0 0 1px rgba(45,70,102,.45), inset 0 20px 40px rgba(5,10,18,.55);
+      width:100%;
+      height:100%;
+      flex:1 1 auto;
     }
     .func-value-label{font-size:12px; letter-spacing:.18em; color:#9aa6bb; text-transform:uppercase}
     .func-value-main{
@@ -272,27 +276,27 @@
     .func-params{
       display:flex;
       flex-wrap:wrap;
-      gap:8px;
+      gap:6px;
       justify-content:center;
     }
     .func-param-btn{
       position:relative;
       border:none;
       background:linear-gradient(150deg, rgba(16,23,35,.85) 0%, rgba(10,15,24,1) 100%);
-      padding:10px 14px;
+      padding:8px 12px;
       border-radius:12px;
       cursor:pointer;
       color:#c9d7f1;
       display:flex;
       align-items:center;
       justify-content:center;
-      min-width:68px;
-      flex:1 0 68px;
-      min-height:48px;
+      min-width:56px;
+      flex:1 0 56px;
+      min-height:40px;
       box-shadow: inset 0 0 0 1px rgba(45,65,92,.55), 0 10px 24px rgba(0,0,0,.4);
       transition:transform .2s ease, box-shadow .2s ease, background .2s ease;
     }
-    .func-param-btn .symbol{font-size:20px; letter-spacing:.1em; text-transform:uppercase; color:#58e4ff; font-weight:600}
+    .func-param-btn .symbol{font-size:18px; letter-spacing:.1em; text-transform:uppercase; color:#58e4ff; font-weight:600}
     .func-param-btn .sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0}
     .func-param-btn::after{
       content:attr(data-tooltip);
@@ -331,7 +335,7 @@
       gap:6px;
       font-size:12px;
       color:#d0def6;
-      min-height:48px;
+      min-height:36px;
       flex:1 1 auto;
       min-width:0;
       white-space:nowrap;
@@ -345,7 +349,6 @@
       gap:6px;
     }
     .func-summary-item.current .func-summary-value{color:#58e4ff}
-    .func-summary-label{font-size:12px; color:#7ea6d9; text-transform:uppercase; letter-spacing:.16em}
     .func-summary-value{font-size:14px; letter-spacing:.04em; color:#e4f1ff; font-weight:600}
     .func-summary-value .unit{font-size:11px; margin-left:3px; letter-spacing:.12em; text-transform:uppercase; color:#7fbfff}
     .func-summary-secondary{font-size:11px; color:#7a8aa6; opacity:.9}
@@ -1623,10 +1626,6 @@
           separator.setAttribute('aria-hidden', 'true');
           funcSummary.appendChild(separator);
         }
-        const label = document.createElement('span');
-        label.className = 'func-summary-label';
-        label.textContent = labelText;
-        item.appendChild(label);
         const value = document.createElement('span');
         value.className = 'func-summary-value';
         value.textContent = formatted.main;


### PR DESCRIPTION
## Summary
- expand the function generator main value container to fill the display area and reduce the summary row height
- remove parameter labels from the summary line and shrink the parameter button sizing for a tighter layout

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68dd95897274832e95e03904990e3383