### PR TITLE
Add GET endpoint for function generator status

### DIFF
--- a/src/services/WebApi.h
+++ b/src/services/WebApi.h
@@ -44,7 +44,8 @@ private:
   void handlePutConfig();
   void handleDmm();
   void handleScope();
-  void handleFuncGen();
+  void handleFuncGenGet();
+  void handleFuncGenPost();
   void handleLogsTail();
   void handleWifiScan();
   void handleIoHardware();


### PR DESCRIPTION
## Summary
- register a GET handler for /api/funcgen so the UI can poll the generator status
- expose the stored function generator configuration through the new handler
- keep the existing POST handler for updating settings

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4bd3b38832e96f88fd90eb27c2a