### PR TITLE
Add diagnostic logging for function generator controls

### DIFF
--- a/src/devices/FuncGen.cpp
+++ b/src/devices/FuncGen.cpp
@@ -7,7 +7,8 @@
 
 FuncGen::FuncGen(Logger *logger, ConfigStore *config)
     : m_settings{SINE, 0.0f, 0.0f, 0.5f, false}, m_logger(logger),
-      m_config(config), m_phase(0.0f), m_lastMicros(0) {}
+      m_config(config), m_phase(0.0f), m_lastMicros(0),
+      m_disabledLogged(false), m_zeroFreqLogged(false) {}
 
 void FuncGen::begin() {
   // Initialise the DAC. It defaults to address 0x60. If the device is
@@ -18,6 +19,8 @@ void FuncGen::begin() {
   loadFromConfig();
   // Set initial lastMicros to current time
   m_lastMicros = micros();
+  m_disabledLogged = false;
+  m_zeroFreqLogged = false;
 }
 
 void FuncGen::loadFromConfig() {
@@ -44,6 +47,13 @@ void FuncGen::loadFromConfig() {
 void FuncGen::updateSettings(const JsonDocument &doc) {
   // Update internal settings from the provided document. Do minimal
   // validation to ensure values stay within [0,1].
+  if (m_logger) {
+    String payload;
+    serializeJson(doc, payload);
+    m_logger->info(String(F("FuncGen updateSettings payload=")) + payload);
+  }
+
+  Settings old = m_settings;
   if (doc.containsKey("type")) {
     const char *typeStr = doc["type"].as<const char *>();
     if (strcasecmp(typeStr, "sine") == 0) {
@@ -70,6 +80,39 @@ void FuncGen::updateSettings(const JsonDocument &doc) {
   if (doc.containsKey("enabled")) {
     m_settings.enabled = doc["enabled"];
   }
+
+  if (m_logger) {
+    String summary = String(F("FuncGen settings => type="));
+    switch (m_settings.type) {
+    case SINE:
+      summary += F("sine");
+      break;
+    case SQUARE:
+      summary += F("square");
+      break;
+    case TRIANGLE:
+      summary += F("triangle");
+      break;
+    }
+    summary += F(", freq=");
+    summary += String(m_settings.freq, 3);
+    summary += F("Hz, amp=");
+    summary += String(m_settings.amp, 3);
+    summary += F(", offset=");
+    summary += String(m_settings.offset, 3);
+    summary += F(", enabled=");
+    summary += (m_settings.enabled ? F("true") : F("false"));
+    m_logger->info(summary);
+
+    if (old.enabled && !m_settings.enabled) {
+      m_logger->warning(F("FuncGen disabled via update"));
+    } else if (!old.enabled && m_settings.enabled) {
+      m_logger->info(F("FuncGen enabled via update"));
+    }
+  }
+
+  m_disabledLogged = false;
+  m_zeroFreqLogged = false;
   // Persist settings to funcgen.json
   JsonDocument &cfg = m_config->getConfig("funcgen");
   cfg["type"] = (m_settings.type == SINE
@@ -84,16 +127,26 @@ void FuncGen::updateSettings(const JsonDocument &doc) {
 
 void FuncGen::loop() {
   if (!m_settings.enabled) {
+    if (m_logger && !m_disabledLogged) {
+      m_logger->debug(F("FuncGen loop skipped: generator disabled"));
+      m_disabledLogged = true;
+    }
     return;
   }
+  m_disabledLogged = false;
   // Compute elapsed time since last call
   unsigned long now = micros();
   unsigned long delta = now - m_lastMicros;
   m_lastMicros = now;
   // If frequency is zero nothing to generate
   if (m_settings.freq <= 0.0f) {
+    if (m_logger && !m_zeroFreqLogged) {
+      m_logger->warning(F("FuncGen loop skipped: frequency <= 0"));
+      m_zeroFreqLogged = true;
+    }
     return;
   }
+  m_zeroFreqLogged = false;
   // Update phase based on elapsed microseconds. Phase wraps around
   // 0..1.
   float inc = (float)delta * m_settings.freq / 1000000.0f;

--- a/src/devices/FuncGen.h
+++ b/src/devices/FuncGen.h
@@ -46,6 +46,8 @@ private:
   Adafruit_MCP4725 m_dac;
   float m_phase;
   unsigned long m_lastMicros;
+  bool m_disabledLogged;
+  bool m_zeroFreqLogged;
 
   // Load settings from funcgen.json. Called during begin().
   void loadFromConfig();

--- a/src/services/WebApi.cpp
+++ b/src/services/WebApi.cpp
@@ -650,12 +650,18 @@ void WebApi::handleFuncGenPost() {
                   "{\"error\":\"missing body\"}");
     return;
   }
+  if (m_logger) {
+    m_logger->info(String(F("HTTP POST /api/funcgen body=")) + body);
+  }
   StaticJsonDocument<512> doc;
   DeserializationError err = deserializeJson(doc, body);
   if (err) {
     m_server.send(400, "application/json",
                   String("{\"error\":\"invalid JSON: ") +
                       err.c_str() + "\"}");
+    if (m_logger) {
+      m_logger->error(String(F("FuncGen POST JSON error: ")) + err.c_str());
+    }
     return;
   }
   m_funcGen->updateSettings(doc);


### PR DESCRIPTION
## Summary
- add internal state flags so the function generator logs when it is disabled or has an invalid frequency
- log the incoming payload and resulting settings when /api/funcgen updates are applied
- record HTTP /api/funcgen request bodies and JSON parsing errors for easier debugging

## Testing
- not run (firmware only)


------
https://chatgpt.com/codex/tasks/task_e_68ddb86525e0832ea6b25af3d318aa71