### PR TITLE
Integrate function generator with configurable outputs

### DIFF
--- a/data/funcgen.json
+++ b/data/funcgen.json
@@ -3,5 +3,6 @@
   "freq": 1000,
   "amp_pct": 50,
   "offset_pct": 50,
-  "enabled": false
+  "enabled": false,
+  "target": "DAC0"
 }

--- a/src/devices/FuncGen.h
+++ b/src/devices/FuncGen.h
@@ -40,7 +40,19 @@ private:
     float amp;    // amplitude as fraction (0–1)
     float offset; // offset as fraction (0–1)
     bool enabled;
+    String targetId;
   } m_settings;
+
+  enum OutputDriver { DRIVER_NONE, DRIVER_MCP4725, DRIVER_PWM };
+
+  struct TargetBinding {
+    OutputDriver driver;
+    String id;
+    uint8_t gpio;
+    uint32_t pwmFreq;
+    uint8_t mcpAddress;
+    bool available;
+  } m_target;
 
   Logger *m_logger;
   ConfigStore *m_config;
@@ -51,11 +63,17 @@ private:
   bool m_zeroFreqLogged;
   bool m_lastEnabledState;
   float m_lastDcLevelLogged;
+  float m_lastOutputValue;
+  bool m_noTargetLogged;
 
   // Load settings from funcgen.json. Called during begin().
   void loadFromConfig();
   // Compute waveform sample at current phase.
   float waveformSample(float phase);
+  void resolveTargetBinding();
+  int labelToGpio(const String &label);
+  void writeOutput(float value);
+  void ensureOutputDisabled();
 };
 
 #endif // MINILABOESP_FUNCGEN_H


### PR DESCRIPTION
## Summary
- allow the function generator to bind to a configured output target and drive either the MCP4725 DAC or PWM pins
- persist the selected target in funcgen.json so the UI can request analog levels on AO outputs

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de6b5ef470832e94cf44fe28eb3fbd