### PR TITLE
Documente les sources de génération des sorties

### DIFF
--- a/data/fonctions-output.json
+++ b/data/fonctions-output.json
@@ -1,0 +1,266 @@
+[
+  {
+    "type": "pwm_rc",
+    "label": "PWM filtrée (RC)",
+    "functions": [
+      {
+        "id": "dc",
+        "label": "Continu (PWM lissée)",
+        "frequency": 5000,
+        "notes": "Variation du rapport cyclique pour générer un niveau continu qui sera filtré par le RC.",
+        "code": [
+          "float level = dcFraction;",
+          "if (level < 0.0f) level = 0.0f;",
+          "if (level > 1.0f) level = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(5000);",
+          "const uint16_t pwm = (uint16_t)roundf(level * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "sine",
+        "label": "Sinusoïde",
+        "frequency": 5000,
+        "notes": "La sinusoïde est calculée dans FuncGen::waveformSample puis convertie en rapport cyclique PWM.",
+        "code": [
+          "const float sample = 0.5f * (1.0f + sinf(phase * 2.0f * PI));",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(5000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "square",
+        "label": "Carré",
+        "frequency": 5000,
+        "notes": "L’état haut ou bas est défini par la phase (<0,5 → +1, sinon −1).",
+        "code": [
+          "const float sample = phase < 0.5f ? 1.0f : -1.0f;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(5000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "triangle",
+        "label": "Triangle",
+        "frequency": 5000,
+        "notes": "Triangle symétrique (−1 → +1) transformé en rapport cyclique lissé.",
+        "code": [
+          "float sample = phase < 0.5f ? 4.0f * phase - 1.0f : 3.0f - 4.0f * phase;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(5000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mcp4725",
+    "label": "DAC I²C MCP4725",
+    "functions": [
+      {
+        "id": "dc",
+        "label": "Continu (DAC)",
+        "notes": "Conversion du niveau normalisé [0,1] en 12 bits pour le MCP4725.",
+        "code": [
+          "float level = dcFraction;",
+          "if (level < 0.0f) level = 0.0f;",
+          "if (level > 1.0f) level = 1.0f;",
+          "const uint16_t dac = (uint16_t)roundf(level * 4095.0f);",
+          "m_dac.setVoltage(dac, false);"
+        ]
+      },
+      {
+        "id": "sine",
+        "label": "Sinusoïde",
+        "notes": "La valeur calculée est directement envoyée au DAC, sans étape PWM.",
+        "code": [
+          "const float sample = 0.5f * (1.0f + sinf(phase * 2.0f * PI));",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "const uint16_t dac = (uint16_t)roundf(value * 4095.0f);",
+          "m_dac.setVoltage(dac, false);"
+        ]
+      },
+      {
+        "id": "square",
+        "label": "Carré",
+        "notes": "Commande haute ou basse suivant la phase, convertie en 12 bits.",
+        "code": [
+          "const float sample = phase < 0.5f ? 1.0f : -1.0f;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "const uint16_t dac = (uint16_t)roundf(value * 4095.0f);",
+          "m_dac.setVoltage(dac, false);"
+        ]
+      },
+      {
+        "id": "triangle",
+        "label": "Triangle",
+        "notes": "Forme triangulaire normalisée envoyée directement au MCP4725.",
+        "code": [
+          "float sample = phase < 0.5f ? 4.0f * phase - 1.0f : 3.0f - 4.0f * phase;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "const uint16_t dac = (uint16_t)roundf(value * 4095.0f);",
+          "m_dac.setVoltage(dac, false);"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "pwm_0_10v",
+    "label": "Convertisseur PWM → 0–10 V",
+    "functions": [
+      {
+        "id": "dc",
+        "label": "Continu (module 0–10 V)",
+        "frequency": 2000,
+        "notes": "Le module industriel convertit le rapport cyclique 0–100 % en 0–10 V.",
+        "code": [
+          "float level = dcFraction;",
+          "if (level < 0.0f) level = 0.0f;",
+          "if (level > 1.0f) level = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(2000);",
+          "const uint16_t pwm = (uint16_t)roundf(level * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "sine",
+        "label": "Sinusoïde",
+        "frequency": 2000,
+        "notes": "La PWM module le convertisseur 0–10 V après adaptation analogique.",
+        "code": [
+          "const float sample = 0.5f * (1.0f + sinf(phase * 2.0f * PI));",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(2000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "square",
+        "label": "Carré",
+        "frequency": 2000,
+        "notes": "Les états haut/bas PWM correspondent à 0 V et 10 V en sortie du module.",
+        "code": [
+          "const float sample = phase < 0.5f ? 1.0f : -1.0f;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(2000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "triangle",
+        "label": "Triangle",
+        "frequency": 2000,
+        "notes": "La tension suit la modulation PWM une fois filtrée par l’étage du module.",
+        "code": [
+          "float sample = phase < 0.5f ? 4.0f * phase - 1.0f : 3.0f - 4.0f * phase;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(2000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "charge_pump_doubler",
+    "label": "Pompe de charge doubleur",
+    "functions": [
+      {
+        "id": "dc",
+        "label": "Continu (pompe de charge)",
+        "frequency": 4000,
+        "notes": "La pompe de charge double la tension effective sur des charges légères grâce au rapport cyclique PWM.",
+        "code": [
+          "float level = dcFraction;",
+          "if (level < 0.0f) level = 0.0f;",
+          "if (level > 1.0f) level = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(4000);",
+          "const uint16_t pwm = (uint16_t)roundf(level * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "sine",
+        "label": "Sinusoïde",
+        "frequency": 4000,
+        "notes": "Le rapport cyclique sinusoïdal charge/décharge les condensateurs pour obtenir ≈2 × Vin.",
+        "code": [
+          "const float sample = 0.5f * (1.0f + sinf(phase * 2.0f * PI));",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(4000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "square",
+        "label": "Carré",
+        "frequency": 4000,
+        "notes": "Les alternances haute/basse alimentent successivement les condensateurs de la pompe de charge.",
+        "code": [
+          "const float sample = phase < 0.5f ? 1.0f : -1.0f;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(4000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      },
+      {
+        "id": "triangle",
+        "label": "Triangle",
+        "frequency": 4000,
+        "notes": "Commande PWM triangulaire appliquée à la pompe de charge (même principe que les autres formes).",
+        "code": [
+          "float sample = phase < 0.5f ? 4.0f * phase - 1.0f : 3.0f - 4.0f * phase;",
+          "float value = offset + amplitude * sample;",
+          "if (value < 0.0f) value = 0.0f;",
+          "if (value > 1.0f) value = 1.0f;",
+          "analogWriteRange(1023);",
+          "analogWriteFreq(4000);",
+          "const uint16_t pwm = (uint16_t)roundf(value * 1023.0f);",
+          "analogWrite(gpio, pwm);"
+        ]
+      }
+    ]
+  }
+]

--- a/data/outputs.html
+++ b/data/outputs.html
@@ -196,6 +196,15 @@
       resize: vertical;
     }
 
+    .detail-panel label.field.readonly {
+      cursor: default;
+    }
+
+    .detail-panel label.field.readonly strong {
+      font-weight: 600;
+      color: #0f2f7a;
+    }
+
     .detail-panel .diagram {
       background: #0f172a;
       color: #e7efff;
@@ -244,6 +253,52 @@
       margin: 0;
     }
 
+    .function-sources {
+      border-top: 1px solid #e0e6f5;
+      padding-top: 0.75rem;
+      display: grid;
+      gap: 0.6rem;
+    }
+
+    .function-sources h4 {
+      margin: 0;
+      font-size: 1rem;
+      color: #1f2f55;
+    }
+
+    .function-sources details {
+      background: #f4f7ff;
+      border: 1px solid #d7deea;
+      border-radius: 10px;
+      padding: 0.4rem 0.6rem;
+    }
+
+    .function-sources details[open] {
+      background: #eef3ff;
+    }
+
+    .function-sources summary {
+      font-weight: 600;
+      color: #1f3d7a;
+      cursor: pointer;
+    }
+
+    .function-sources p {
+      margin: 0.4rem 0 0.6rem 0;
+      color: #2e3f60;
+      font-size: 0.92rem;
+    }
+
+    .function-sources pre {
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 8px;
+      padding: 0.6rem;
+      margin: 0;
+      font-size: 0.85rem;
+      overflow-x: auto;
+    }
+
     @media (max-width: 920px) {
       .layout {
         grid-template-columns: 1fr;
@@ -266,7 +321,7 @@
         <p>Génère une tension analogique lissée à partir d’une PWM entre 1&nbsp;kHz et 40&nbsp;kHz. Le filtre de base est constitué d’une résistance de 10&nbsp;kΩ et d’un condensateur de 10&nbsp;µF.</p>
         <ul>
           <li>Idéale pour piloter des servos analogiques, des références de consigne ou injecter un signal lent.</li>
-          <li>Choisissez la broche PWM, la fréquence et, si besoin, adaptez la constante de temps du filtre.</li>
+          <li>Choisissez la broche PWM et, si besoin, adaptez la constante de temps du filtre ; la fréquence est déterminée par le profil de fonction.</li>
         </ul>
       </article>
       <article>
@@ -474,6 +529,7 @@
   let hardwareProfiles = [];
   let outputs = [];
   let selectedIndex = -1;
+  let functionSources = {};
 
   const statusEl = document.getElementById('status');
   const tableBody = document.querySelector('#outputsTable tbody');
@@ -505,6 +561,25 @@
     return target;
   }
 
+  function formatFrequency(value) {
+    if (typeof value === 'number' && isFinite(value) && value > 0) {
+      return `${value.toLocaleString('fr-FR')} Hz`;
+    }
+    return 'Défaut matériel';
+  }
+
+  function createReadOnlyField(label, value) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'field readonly';
+    const span = document.createElement('span');
+    span.textContent = label;
+    wrapper.appendChild(span);
+    const strong = document.createElement('strong');
+    strong.textContent = value;
+    wrapper.appendChild(strong);
+    return wrapper;
+  }
+
   function ensureHardwareProfiles() {
     if (!hardwareProfiles.length) {
       hardwareProfiles = DEFAULT_OUTPUT_PROFILES.map(def => deepClone(def));
@@ -517,6 +592,73 @@
   function findProfile(type) {
     const map = ensureHardwareProfiles();
     return map.get(type) || null;
+  }
+
+  function loadFunctionSources() {
+    return fetch('/fonctions-output.json')
+      .then(res => (res.ok ? res.json() : {}))
+      .then(data => {
+        functionSources = {};
+        if (Array.isArray(data)) {
+          data.forEach(entry => {
+            if (entry && entry.type) {
+              functionSources[entry.type] = entry;
+            }
+          });
+        } else if (data && typeof data === 'object') {
+          Object.keys(data).forEach(key => {
+            functionSources[key] = data[key];
+          });
+        }
+      })
+      .catch(() => {
+        functionSources = {};
+      });
+  }
+
+  function renderFunctionSources(container, output) {
+    if (!output || !output.type) return;
+    const entry = functionSources[output.type];
+    if (!entry) return;
+    const functions = Array.isArray(entry.functions) ? entry.functions : [];
+    if (!functions.length) return;
+
+    const section = document.createElement('section');
+    section.className = 'function-sources';
+    const heading = document.createElement('h4');
+    heading.textContent = 'Génération du signal';
+    section.appendChild(heading);
+
+    functions.forEach(fn => {
+      if (!fn) return;
+      const details = document.createElement('details');
+      if (fn.id === 'dc') details.open = true;
+      const summary = document.createElement('summary');
+      const label = fn.label || fn.id || 'Fonction';
+      const freq = fn.frequency ? formatFrequency(fn.frequency) : null;
+      summary.textContent = freq ? `${label} – ${freq}` : label;
+      details.appendChild(summary);
+
+      if (fn.notes) {
+        const notes = document.createElement('p');
+        notes.textContent = fn.notes;
+        details.appendChild(notes);
+      }
+
+      const pre = document.createElement('pre');
+      if (Array.isArray(fn.code)) {
+        pre.textContent = fn.code.join('\n');
+      } else if (typeof fn.code === 'string') {
+        pre.textContent = fn.code;
+      } else {
+        pre.textContent = '// TODO: implémenter';
+      }
+      details.appendChild(pre);
+
+      section.appendChild(details);
+    });
+
+    container.appendChild(section);
   }
 
   function createUniqueId(base) {
@@ -891,17 +1033,11 @@
           config.frequency = mode.frequency;
         }
         renderTable();
+        renderDetailPanel();
       }
     }));
 
-    form.appendChild(bindInput('Fréquence PWM (Hz)', config.frequency, {
-      type: 'number',
-      step: '1',
-      min: 1,
-      onChange: event => {
-        config.frequency = Number(event.target.value);
-      }
-    }));
+    form.appendChild(createReadOnlyField('Fréquence PWM imposée', formatFrequency(config.frequency)));
 
     form.appendChild(bindInput('Résistance R (Ω)', config.filter.r_ohm, {
       type: 'number',
@@ -977,6 +1113,7 @@
     notes.innerHTML = `
       <li>Constante de temps τ = R × C. Avec 10 kΩ / 10 µF → τ ≈ 0,1 s.</li>
       <li>Pour des réponses plus rapides, augmenter la fréquence PWM ou diminuer C.</li>
+      <li>Le niveau continu est obtenu en modulant le rapport cyclique de la PWM pilotée par le générateur de fonctions.</li>
     `;
 
     container.appendChild(form);
@@ -1104,18 +1241,11 @@
         const mode = pwm10Modes.find(m => m.id === config.pwmMode);
         if (mode && mode.frequency) config.frequency = mode.frequency;
         renderTable();
+        renderDetailPanel();
       }
     }));
 
-    form.appendChild(bindInput('Fréquence PWM (Hz)', config.frequency, {
-      type: 'number',
-      step: '1',
-      min: 1000,
-      max: 3000,
-      onChange: event => {
-        config.frequency = Number(event.target.value);
-      }
-    }));
+    form.appendChild(createReadOnlyField('Fréquence PWM imposée', formatFrequency(config.frequency)));
 
     form.appendChild(bindInput('Alimentation module (V)', config.supply.voltage, {
       type: 'number',
@@ -1263,18 +1393,11 @@
           config.frequency = mode.frequency;
         }
         renderTable();
+        renderDetailPanel();
       }
     }));
 
-    form.appendChild(bindInput('Fréquence PWM (Hz)', config.frequency, {
-      type: 'number',
-      step: '1',
-      min: 1,
-      onChange: event => {
-        config.frequency = Number(event.target.value);
-        renderTable();
-      }
-    }));
+    form.appendChild(createReadOnlyField('Fréquence PWM imposée', formatFrequency(config.frequency)));
 
     form.appendChild(bindInput('Capacité pompe (µF)', config.pump.c_uF, {
       type: 'number',
@@ -1432,31 +1555,36 @@
              │ │ C (${output.config.filter?.c_uF || 'C'} µF)
              │ │
              └─┘
-              │
-             GND</pre>`;
+             │
+            GND</pre>`;
       detailPanel.appendChild(diagram);
       renderPwmRcDetails(detailPanel, output, profile);
+      renderFunctionSources(detailPanel, output);
       return;
     }
 
     if (output.type === 'mcp4725') {
       renderMcpDetails(detailPanel, output, profile);
+      renderFunctionSources(detailPanel, output);
       return;
     }
 
     if (output.type === 'pwm_0_10v') {
       renderPwm10Details(detailPanel, output, profile);
+      renderFunctionSources(detailPanel, output);
       return;
     }
 
     if (output.type === 'charge_pump_doubler') {
       renderChargePumpDetails(detailPanel, output, profile);
+      renderFunctionSources(detailPanel, output);
       return;
     }
 
     const p = document.createElement('p');
     p.textContent = 'Aucun formulaire disponible pour ce type.';
     detailPanel.appendChild(p);
+    renderFunctionSources(detailPanel, output);
   }
 
   function loadConfiguration() {
@@ -1528,7 +1656,9 @@
     saveConfiguration();
   });
 
-  loadHardwareCapabilities().then(() => loadConfiguration());
+  Promise.all([loadHardwareCapabilities(), loadFunctionSources()])
+    .then(() => loadConfiguration())
+    .catch(() => loadConfiguration());
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the new `fonctions-output.json` catalogue describing the code snippets and PWM frequencies for each output type
- update `outputs.html` to fetch those sources, show read-only PWM frequencies, and drop the manual frequency selector
- clarify the PWM RC documentation and ensure the configuration loads after hardware/functions metadata

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68de8ade70c4832e804250470bcb588b